### PR TITLE
Add subtitle to annotation when there's only one object in the cluster

### DIFF
--- a/ABFRealmMapView/ABFLocationFetchedResultsController.m
+++ b/ABFRealmMapView/ABFLocationFetchedResultsController.m
@@ -545,6 +545,7 @@ ABFClusterSizeForZoomLevel ABFDefaultClusterSizeForZoomLevel()
                 ABFLocationSafeRealmObject *safeObject = cluster.firstObject;
                 
                 title = safeObject.title;
+                [annotation setSubtitle:safeObject.subtitle];
             }
             
             [annotation setTitle:title];


### PR DESCRIPTION
Maybe this isn't desired behavior- but it seems like map annotations should show the subtitle in the callout when there's only one object in the annotation's cluster.