### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you still have questions, a slightly longer tutorial is available [here](http
 `ABFRealmMapView` is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
-_**Starting with Xcode 7.1, there is an issue with Cocoapods 0.39 that caused the interop of the Objective-C code for `ABFRealmMapView` to fail on compile when used in `RealmMapView`. This problem has now been resolved as of v1.6.6. Please be sure to use this version or higher with Xcode 7.1.**_
+_**Starting with Xcode 7.1, there is an issue with CocoaPods 0.39 that caused the interop of the Objective-C code for `ABFRealmMapView` to fail on compile when used in `RealmMapView`. This problem has now been resolved as of v1.6.6. Please be sure to use this version or higher with Xcode 7.1.**_
 
 **Objective-C**
 ```


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
